### PR TITLE
add shell env to current cc env for all foreign actions

### DIFF
--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -227,17 +227,19 @@ def get_env_vars(ctx):
     )
     copts = ctx.attr.copts if hasattr(ctx.attr, "copts") else []
 
+    toolchain_variables = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        user_compile_flags = copts,
+    )
+
     vars = dict()
 
-    for action_name in [C_COMPILE_ACTION_NAME, CPP_LINK_STATIC_LIBRARY_ACTION_NAME, CPP_LINK_EXECUTABLE_ACTION_NAME]:
+    for action_name in [C_COMPILE_ACTION_NAME, CPP_LINK_STATIC_LIBRARY_ACTION_NAME, CPP_LINK_EXECUTABLE_ACTION_NAME, CPP_LINK_DINAMYC_LIBRARY_ACTION_NAME]:
         vars.update(cc_common.get_environment_variables(
             feature_configuration = feature_configuration,
             action_name = action_name,
-            variables = cc_common.create_compile_variables(
-                feature_configuration = feature_configuration,
-                cc_toolchain = cc_toolchain,
-                user_compile_flags = copts,
-            ),
+            variables = toolchain_variables,
         ))
     return vars
 

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -235,7 +235,7 @@ def get_env_vars(ctx):
 
     vars = dict()
 
-    for action_name in [C_COMPILE_ACTION_NAME, CPP_LINK_STATIC_LIBRARY_ACTION_NAME, CPP_LINK_EXECUTABLE_ACTION_NAME, CPP_LINK_DINAMYC_LIBRARY_ACTION_NAME]:
+    for action_name in [C_COMPILE_ACTION_NAME, CPP_LINK_STATIC_LIBRARY_ACTION_NAME, CPP_LINK_EXECUTABLE_ACTION_NAME, CPP_LINK_DYNAMIC_LIBRARY_ACTION_NAME]:
         vars.update(cc_common.get_environment_variables(
             feature_configuration = feature_configuration,
             action_name = action_name,

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -297,7 +297,9 @@ def cc_external_rule_impl(ctx, attrs):
     outputs = _define_outputs(ctx, attrs, lib_name)
     out_cc_info = _define_out_cc_info(ctx, attrs, inputs, outputs)
 
-    cc_env = _correct_path_variable(get_env_vars(ctx))
+    cc_env = get_env_vars(ctx)
+    cc_env.update(ctx.configuration.default_shell_env)
+    cc_env = _correct_path_variable(cc_env)
     set_cc_envs = ""
     execution_os_name = os_name(ctx)
     if execution_os_name != "osx":

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -398,12 +398,11 @@ def cc_external_rule_impl(ctx, attrs):
         extra_tools.append(wrapper)
         wrapper = batch_wrapper
 
-    print(cc_env)
-
     ctx.actions.run(
         mnemonic = "Cc" + attrs.configure_name.capitalize() + "MakeRule",
         inputs = depset(
             inputs.declared_inputs,
+            transitive = [cc_toolchain.all_files],
         ),
         outputs = rule_outputs + [
             empty.file,
@@ -411,11 +410,11 @@ def cc_external_rule_impl(ctx, attrs):
         ],
         tools = depset(
             [wrapped_outputs.script_file] + extra_tools + ctx.files.data + ctx.files.tools_deps + ctx.files.additional_tools,
-            transitive = [cc_toolchain.all_files] + [data[DefaultInfo].default_runfiles.files for data in data_dependencies],
+            transitive = [data[DefaultInfo].default_runfiles.files for data in data_dependencies],
         ),
         # TODO: Default to never using the default shell environment to make builds more hermetic. For now, every platform
         # but MacOS will take the default PATH passed by Bazel, not that from cc_toolchain.
-        use_default_shell_env = False,# execution_os_name != "osx",
+        use_default_shell_env = execution_os_name != "osx",
         executable = wrapper,
         execution_requirements = execution_requirements,
         # this is ignored if use_default_shell_env = True

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -297,9 +297,8 @@ def cc_external_rule_impl(ctx, attrs):
     outputs = _define_outputs(ctx, attrs, lib_name)
     out_cc_info = _define_out_cc_info(ctx, attrs, inputs, outputs)
 
-    cc_env = get_env_vars(ctx)
+    cc_env = _correct_path_variable(get_env_vars(ctx))
     cc_env.update(ctx.configuration.default_shell_env)
-    cc_env = _correct_path_variable(cc_env)
     set_cc_envs = ""
     execution_os_name = os_name(ctx)
     if execution_os_name != "osx":
@@ -335,6 +334,7 @@ def cc_external_rule_impl(ctx, attrs):
         )
         for key, value in getattr(ctx.attr, "env", {}).items()
     ]
+    print(define_variables)
 
     make_commands = []
     for line in attrs.make_commands:

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -298,9 +298,6 @@ def cc_external_rule_impl(ctx, attrs):
     out_cc_info = _define_out_cc_info(ctx, attrs, inputs, outputs)
 
     cc_env = _correct_path_variable(get_env_vars(ctx))
-    print(cc_env)
-    cc_env.update(ctx.configuration.default_shell_env)
-    print(ctx.configuration.default_shell_env)
     set_cc_envs = ""
     execution_os_name = os_name(ctx)
     if execution_os_name != "osx":
@@ -401,9 +398,14 @@ def cc_external_rule_impl(ctx, attrs):
         extra_tools.append(wrapper)
         wrapper = batch_wrapper
 
+    print(cc_toolchain.all_files)
+
     ctx.actions.run(
         mnemonic = "Cc" + attrs.configure_name.capitalize() + "MakeRule",
-        inputs = depset(inputs.declared_inputs),
+        inputs = depset(
+            inputs.declared_inputs,
+            transitive = [cc_toolchain.all_files],
+        ),
         outputs = rule_outputs + [
             empty.file,
             wrapped_outputs.log_file,

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -298,7 +298,9 @@ def cc_external_rule_impl(ctx, attrs):
     out_cc_info = _define_out_cc_info(ctx, attrs, inputs, outputs)
 
     cc_env = _correct_path_variable(get_env_vars(ctx))
+    print(cc_env)
     cc_env.update(ctx.configuration.default_shell_env)
+    print(ctx.configuration.default_shell_env)
     set_cc_envs = ""
     execution_os_name = os_name(ctx)
     if execution_os_name != "osx":
@@ -334,7 +336,6 @@ def cc_external_rule_impl(ctx, attrs):
         )
         for key, value in getattr(ctx.attr, "env", {}).items()
     ]
-    print(define_variables)
 
     make_commands = []
     for line in attrs.make_commands:
@@ -413,7 +414,7 @@ def cc_external_rule_impl(ctx, attrs):
         ),
         # TODO: Default to never using the default shell environment to make builds more hermetic. For now, every platform
         # but MacOS will take the default PATH passed by Bazel, not that from cc_toolchain.
-        use_default_shell_env = execution_os_name != "osx",
+        use_default_shell_env = False,# execution_os_name != "osx",
         executable = wrapper,
         execution_requirements = execution_requirements,
         # this is ignored if use_default_shell_env = True

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -317,8 +317,6 @@ def cc_external_rule_impl(ctx, attrs):
     # we need this fictive file in the root to get the path of the root in the script
     empty = fictive_file_in_genroot(ctx.actions, ctx.label.name)
 
-    cc_toolchain = find_cpp_toolchain(ctx)
-
     data_dependencies = ctx.attr.data + ctx.attr.tools_deps + ctx.attr.additional_tools
 
     define_variables = [
@@ -331,7 +329,7 @@ def cc_external_rule_impl(ctx, attrs):
         "export {key}={value}".format(
             key = key,
             # Prepend the exec root to each $(execpath ) lookup because the working directory will not be the exec root.
-            value = ctx.expand_location(value.replace("$(execpath ", "$$EXT_BUILD_ROOT$$/$(execpath "), data_dependencies + [cc_toolchain.all_files]),
+            value = ctx.expand_location(value.replace("$(execpath ", "$$EXT_BUILD_ROOT$$/$(execpath "), data_dependencies),
         )
         for key, value in getattr(ctx.attr, "env", {}).items()
     ]
@@ -376,7 +374,8 @@ def cc_external_rule_impl(ctx, attrs):
     wrapped_outputs = wrap_outputs(ctx, lib_name, attrs.configure_name, script_text)
 
     rule_outputs = outputs.declared_outputs + [installdir_copy.file]
-
+    cc_toolchain = find_cpp_toolchain(ctx)
+    
     execution_requirements = {"block-network": ""}
     if "requires-network" in ctx.attr.tags:
         execution_requirements = {"requires-network": ""}
@@ -399,7 +398,7 @@ def cc_external_rule_impl(ctx, attrs):
         extra_tools.append(wrapper)
         wrapper = batch_wrapper
 
-    print(define_variables)
+    print(cc_env)
 
     ctx.actions.run(
         mnemonic = "Cc" + attrs.configure_name.capitalize() + "MakeRule",


### PR DESCRIPTION
The environment used to execute actions is too strict, as it is actually restricting access to the toolchain during the call to configure scripts. This fixes it by updating the current env with the default one for shell actions.

Tracking PR on mainstream, not working on windows right now:
https://github.com/bazelbuild/rules_foreign_cc/pull/543